### PR TITLE
2024 05 05 Update to v6.5a

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+v6.5a 2024-05-08		
+	Fixed a bug that caused 'No ignore damage' to also ignore FNP.	
+	Added possibilty of using both the 'Sum' and 'Pick Best' Input columns in the same row.	
+	Removed dark mode. This was sadly too much of a hassle to maintain.	
+	Removed various deprecated features:	
+	 - The auto wound column in the Input sheet,	
+	 - the legacy melta and d6 (minimum 3) damage stats,	
+	 - the All is Dust column in the Targets sheet, and	
+	 - the Robust Invuls column in the Targets sheet.	
+	Updated targets.	
+
 v6.4c 2024-04-25
 	File size optimization.
 	Updated targets.


### PR DESCRIPTION
This PR is a preparation for the later addition of global rules / army rules. It mostly cleans up old trash to save space, but also fixes a couple of things.

These are the changes:
- Removed Robust Invuls
- Target count cleanup
- Removed deprecated damage stats
- Removed naive avg damage sheet
- Removed All is Dust
- Replaced individual name/weapon formulas with ranges
- Fixed the 'No Ignore Damage FNP' bug.
- Redesigned Sum/Pick Best to have them both work on the same row at the same time.
- Removed dark mode.